### PR TITLE
INFRA-25_fix: Remove unneeded install step

### DIFF
--- a/orb.yaml
+++ b/orb.yaml
@@ -142,9 +142,8 @@ jobs:
           default: []
     steps:
       - checkout
-      - gcp-cli/install:
-          version: << parameters.google-gcloud-version >>
       - gcp-cli/setup:
+          version: << parameters.google-gcloud-version >>
           gcloud_service_key: << parameters.gcloud-service-key >>
           google_compute_region: << parameters.google-compute-region >>
           google_compute_zone: << parameters.google-compute-zone >>


### PR DESCRIPTION
**Note: Please delete any sections that are not relevant for the review rather than just leaving them blank** 

## Description

Remove unneeded install step to stop latest version of gcloud always being installed.

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
